### PR TITLE
Add small script to build docker images

### DIFF
--- a/push-to-docker.sh
+++ b/push-to-docker.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eux
+
+function build_bot() {
+    docker build -t slurk/$1-bot -f $1/Dockerfile .
+    docker push slurk/$1-bot
+}
+
+build_bot minimal
+build_bot echo
+build_bot concierge
+build_bot math
+build_bot dito
+


### PR DESCRIPTION
Currently, the docker images can't be build automatically. Until this is resolved, this script is a short script to build and upload the bots.