### PR TITLE
update of math bot from: https://github.com/janagoetze/slurk-bots/tre…

### DIFF
--- a/math/math_bot.py
+++ b/math/math_bot.py
@@ -147,7 +147,7 @@ class MathBot:
             self.sio.emit(
                 "text",
                 {
-                    "message": "Ups, no question found you could answer!",
+                    "message": "Oops, no question found you could answer!",
                     "room": room_id, "receiver_id": user_id
                 },
                 callback=self.message_callback

--- a/math/math_bot_permissions.json
+++ b/math/math_bot_permissions.json
@@ -1,5 +1,6 @@
 {
     "api": true,
     "send_message": true,
-    "send_privately": true
+    "send_privately": true,
+    "send_html_message": true
 }

--- a/math/math_task_layout.json
+++ b/math/math_task_layout.json
@@ -1,0 +1,84 @@
+{
+    "title": "Math Task Room",
+    "html": [
+        {
+            "layout-type": "div",
+            "id": "typing",
+            "style": "margin: 5px 10px; min-height: 20px"
+        },
+        {
+            "layout-type": "div",
+            "class": "card",
+            "layout-content": [
+                {
+                    "layout-type": "div",
+                    "layout-content": [
+                        {
+                            "layout-type": "b",
+                            "layout-content": [
+                                {
+                                    "layout-type": "lighter",
+                                    "id": "instr_title",
+                                    "style": "min-height: 20px"
+                                }
+                            ]
+                        }
+                    ],
+                    "style": "color: #abb2b9;"
+                },
+                {
+                    "layout-type": "hr",
+                    "layout-content": "",
+                    "style": "margin: 2px; background-color: #abb2b9; opacity: .50;"
+                },
+                {
+                    "layout-type": "div",
+                    "id": "instr",
+                    "style": "white-space: pre-wrap;"
+                },
+                {
+                    "layout-type": "div",
+                    "id": "image-area",
+                    "layout-content": [
+                        {
+                            "layout-type": "image",
+                            "id": "current-image",
+                            "style": "min-width: 70vmin; max-width: 100%; height: auto; object-fit: contain; padding: 2%;"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "css": {
+            ".card": {
+                "position": "relative",
+                "display": "flex",
+                "flex-direction": "column",
+                "min-width": "0",
+                "background-color": "#fff",
+                "background-clip": "border-box",
+                "border": "1px solid rgba(0,0,0,.125)",
+                "border-radius": ".25rem",
+                "height": "100vh!important",
+                "margin": "0px 15px",
+                "padding": "20px"
+            },
+            "time:before": {
+                "content": "''"
+            },
+            "#image-area": {
+                "margin": "0 auto"
+            },
+            "#instr": {
+                "text-align": "center"
+            }
+    },
+    "scripts": {
+        "incoming-text": "markdown",
+        "incoming-image": "display-image",
+        "submit-message": "send-message",
+        "print-history": ["attribute-history", "markdown-history"],
+        "typing-users": "typing-users"
+    }
+}

--- a/math/math_user_permissions.json
+++ b/math/math_user_permissions.json
@@ -1,0 +1,4 @@
+{
+    "send_command": true,
+    "send_message": true
+}

--- a/math/setup.sh
+++ b/math/setup.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -eu
+
+function errcho {
+    echo "$@" 1>&2
+}
+
+function check_response {
+    response=$("$@")
+    if [ -z "$response" ]; then
+        errcho "Unexpected error for call to: $1"
+        exit 1
+    fi
+    echo "$response"
+}
+
+# build docker images for bots
+cd ../slurk-bots
+docker build --tag "slurk/math-bot" -f math/Dockerfile .
+docker build --tag "slurk/concierge-bot" -f concierge/Dockerfile .
+
+# run slurk
+cd ../slurk
+docker build --tag="slurk/server" -f Dockerfile .
+export SLURK_DOCKER=slurk
+scripts/start_server.sh
+sleep 5
+
+# create admin token
+SLURK_TOKEN=$(check_response scripts/read_admin_token.sh)
+echo "Admin Token:"
+echo $SLURK_TOKEN
+
+# create waiting room + layout
+WAITING_ROOM_LAYOUT=$(check_response scripts/create_layout.sh ../slurk-bots/concierge/waiting_room_layout.json | jq .id)
+echo "Waiting Room Layout Id:"
+echo $WAITING_ROOM_LAYOUT
+WAITING_ROOM=$(check_response scripts/create_room.sh $WAITING_ROOM_LAYOUT | jq .id)
+echo "Waiting Room Id:"
+echo $WAITING_ROOM
+
+# create task room layout
+TASK_ROOM_LAYOUT=$(check_response scripts/create_layout.sh ../slurk-bots/math/math_task_layout.json | jq .id)
+echo "Task Room Layout Id:"
+echo $TASK_ROOM_LAYOUT
+
+# create math task
+TASK_ID=$(check_response scripts/create_task.sh  "Math Task" 2 "$TASK_ROOM_LAYOUT" | jq .id)
+echo "Task Id:"
+echo $TASK_ID
+
+# create concierge bot
+CONCIERGE_BOT_TOKEN=$(check_response scripts/create_room_token.sh $WAITING_ROOM ../slurk-bots/concierge/concierge_bot_permissions.json | jq .id | sed 's/^"\(.*\)"$/\1/')
+echo "Concierge Bot Token:"
+echo $CONCIERGE_BOT_TOKEN
+CONCIERGE_BOT=$(check_response scripts/create_user.sh "ConciergeBot" $CONCIERGE_BOT_TOKEN | jq .id)
+echo "Concierge Bot Id:"
+echo $CONCIERGE_BOT
+docker run -e SLURK_TOKEN="$CONCIERGE_BOT_TOKEN" -e SLURK_USER=$CONCIERGE_BOT -e SLURK_PORT=5000 --net="host" slurk/concierge-bot &
+sleep 5
+
+# create math bot
+MATH_BOT_TOKEN=$(check_response scripts/create_room_token.sh $WAITING_ROOM ../slurk-bots/math/math_bot_permissions.json | jq .id | sed 's/^"\(.*\)"$/\1/')
+echo "Math Bot Token: "
+echo $MATH_BOT_TOKEN
+MATH_BOT=$(check_response scripts/create_user.sh "MathBot" "$MATH_BOT_TOKEN" | jq .id)
+echo "Math Bot Id:"
+echo $MATH_BOT
+docker run -e SLURK_TOKEN=$MATH_BOT_TOKEN -e SLURK_USER=$MATH_BOT -e MATH_TASK_ID=$TASK_ID -e SLURK_PORT=5000 --net="host" slurk/math-bot &
+sleep 5
+
+# create users
+USER1=$(check_response scripts/create_room_token.sh $WAITING_ROOM ../slurk-bots/math/math_user_permissions.json 1 $TASK_ID | jq .id | sed 's/^"\(.*\)"$/\1/')
+echo "User 1 Token:"
+echo $USER1
+
+USER2=$(check_response scripts/create_room_token.sh $WAITING_ROOM ../slurk-bots/math/math_user_permissions.json 1 $TASK_ID | jq .id | sed 's/^"\(.*\)"$/\1/')
+echo "User 2 Token:"
+echo $USER2
+
+cd ../slurk-bots

--- a/math/task_description.txt
+++ b/math/task_description.txt
@@ -1,0 +1,12 @@
+Welcome to the Math-Bot! You have been matched to another user.
+
+With the command /question [your math expression here] you can send a math question to the room.
+
+The bot will forward it to all the users and once a question is in the room you and other users can answer it with the command /answer [your answer here].
+
+Once an answer will be accepted, the Bot will check if it is correct.
+
+Try some of these questions or create your own!
+/question (3*4)/2
+/question ((4**2)/3)*1.5 + 42
+/question 143 - 20*2


### PR DESCRIPTION
this pull requests merges the changes dones on the [demo branch](https://github.com/janagoetze/slurk-bots/tree/demos/math)
Main changes:
* new task room layout with a background image, task description and some examples for the user
* user input is evaluated using the [ast module](https://docs.python.org/3/library/ast.html) instead of eval(). For questions, only ast.BinOps are accepted as good mathematical questions and answers are converted to floats. If the user input is malformed, the user will be notified before saving the question/answer.
* with the ```setup.py```script it is possible to quickly start slurk and the math bot for testing

This should probably be merged after the [wordle bot](https://github.com/clp-research/slurk-bots/pull/39)