### PR TITLE
Enforce strict check before parsing expressions

### DIFF
--- a/math/math_bot.py
+++ b/math/math_bot.py
@@ -1,7 +1,6 @@
 import ast
 import argparse
 import logging
-from math import *
 import os
 from pathlib import Path
 import re
@@ -35,7 +34,7 @@ class MathBot:
             self.uri += f":{port}"
         self.uri += "/slurk/api"
 
-        self.questions = dict()
+        self.room_to_q = dict()
 
         LOG.info(f"Running math bot on {self.uri} with token {self.token}")
         # register all event handlers
@@ -94,135 +93,132 @@ class MathBot:
         @self.sio.event
         def command(data):
             """Process question and answer turns for both parties."""
+
             room_id = data["room"]
             user_id = data["user"]["id"]
-            if data["command"].startswith("question"):
+            cmd = data["command"]
+
+            if cmd.startswith("question"):
+                self._set_question(room_id, user_id, cmd)
+            elif cmd.startswith("answer"):
+                self._give_answer(room_id, user_id, cmd)
+            else:
+                # inform the user in case of an invalid command
                 self.sio.emit(
                     "text",
-                    {"message": "You have sent a question.",
-                     "room": room_id,
-                     "receiver_id": user_id},
+                    {
+                        "message": f"`{cmd}` is not a valid command.",
+                        "room": room_id, "receiver_id": user_id
+                    },
                     callback=self.message_callback
                 )
-                self._command_question(user_id, room_id, data["command"])
-            elif data["command"].startswith("answer"):
+
+    def _set_question(self, room_id, user_id, cmd):
+        question = re.sub(r"^question\s*", "", cmd)
+        solution = self._eval(question)
+
+        if solution is None:
+            self.sio.emit(
+                "text",
+                {
+                    "message": "Questions must be mathematical expressions.",
+                    "room": room_id, "receiver_id": user_id
+                },
+                callback=self.message_callback
+            )
+        else:
+            self.room_to_q[room_id] = {
+                "question": question, "solution": solution, "sender": user_id
+            }
+            self.sio.emit(
+                "text",
+                {
+                    "message": f"A new question has been created:\n{question}",
+                    "room": room_id
+                },
+                callback=self.message_callback
+            )
+
+    def _give_answer(self, room_id, user_id, cmd):
+        answer = re.sub(r"^answer\s*", "", cmd)
+        prop_solution = self._eval(answer, answer=True)
+
+        if room_id not in self.room_to_q:
+            self.sio.emit(
+                "text",
+                {
+                    "message": "Ups, no question found you could answer!",
+                    "room": room_id, "receiver_id": user_id
+                },
+                callback=self.message_callback
+            )
+        elif self.room_to_q[room_id]["sender"] == user_id:
+            self.sio.emit(
+                "text",
+                {
+                    "message": "Come on! Don't answer your own question.",
+                    "room": room_id, "receiver_id": user_id
+                },
+                callback=self.message_callback
+            )
+        elif prop_solution is None:
+            self.sio.emit(
+                "text",
+                {
+                    "message": "What? Sure that's a number?",
+                    "room": room_id, "receiver_id": user_id
+                },
+                callback=self.message_callback
+            )
+        else:
+            self.sio.emit(
+                "text",
+                {
+                    "message": f"The proposed answer is: {answer}",
+                    "room": room_id
+                },
+                callback=self.message_callback
+            )
+            if prop_solution == self.room_to_q[room_id]["solution"]:
                 self.sio.emit(
                     "text",
-                    {"message": "You have sent an answer.",
-                     "room": room_id,
-                     "receiver_id": user_id},
+                    {
+                        "message": "Wow! That's indeed correct.",
+                        "room": room_id
+                    },
                     callback=self.message_callback
                 )
-                self._command_answer(user_id, room_id, data["command"])
+                self.room_to_q.pop(room_id)
             else:
                 self.sio.emit(
                     "text",
-                    {"message": f"`{data['command']}` is not a valid command.",
-                     "room": room_id,
-                     "receiver_id": user_id},
+                    {
+                        "message": "Naahh. Try again!",
+                        "room": room_id
+                    },
                     callback=self.message_callback
                 )
 
-    def _command_question(self, user_id, room_id, command):
-        """Broadcast math question to the room."""
-        query = re.sub(r"^question\s*", "", command)
-
+    @staticmethod
+    def _eval(expr, answer=False):
         try:
-            # try to parse the input from user into a math formula
-            tree = ast.parse(query, mode='eval')
-            if not isinstance(tree.body, ast.BinOp):
-                raise SyntaxError
-
-            co = compile(tree, filename='<string>', mode='eval')
-            self.questions[room_id] = co
-            self.questions["sender"] = user_id
-
-            self.sio.emit(
-                "text",
-                {"message": "A math question has been created!",
-                "room": room_id},
-                callback=self.message_callback
-            )
-            self.sio.emit(
-                "text",
-                {"message": query,
-                "room": room_id},
-                callback=self.message_callback
-            )
-
-        except (SyntaxError, NameError):
-            # user input is malformed, inform user
-            self.sio.emit(
-                "text",
-                {"message": "Your question is malformed, please try again",
-                 "room": room_id,
-                 "receiver_id": user_id},
-                callback=self.message_callback
-            )
-
-    def _command_answer(self, user_id, room_id, command):
-        """Check if the provided answer is correct."""
-        answer = re.sub(r"^answer\s*", "", command)
-
-        try:
-            # only proceed if the user entered a number as an answer
-            answer = float(answer)
-            if room_id not in self.questions:
-                self.sio.emit(
-                    "text",
-                    {"message": "Oops, no question found that you could answer!",
-                    "room": room_id,
-                    "receiver_id": user_id},
-                    callback=self.message_callback
-                )
+            tree = ast.parse(expr, mode='eval')
+        except SyntaxError:
+            return
+        # verify the expression
+        for node in ast.walk(tree.body):
+            if not isinstance(node, (
+                ast.Num, ast.Sub, ast.Add, ast.Mult,
+                ast.BinOp, ast.USub, ast.UnaryOp,
+                ast.Div, ast.FloorDiv, ast.Pow
+            )):
                 return
-            if self.questions["sender"] != user_id:
-                self.sio.emit(
-                    "text",
-                    {"message": f"The proposed answer is: {answer}",
-                    "room": room_id},
-                    callback=self.message_callback
-                )
-                if eval(self.questions[room_id]) == answer:
-                    self.sio.emit(
-                        "text",
-                        {"message": "Turns out the answer is correct!",
-                        "room": room_id},
-                        callback=self.message_callback
-                    )
-                else:
-                    self.sio.emit(
-                        "text",
-                        {"message": "Unfortunately the answer is wrong.",
-                        "room": room_id},
-                        callback=self.message_callback
-                    )
-                    self.sio.emit(
-                        "text",
-                        {"message": "Please try again!",
-                        "room": room_id,
-                        "receiver_id": user_id},
-                        callback=self.message_callback
-                    )
-            else:
-                self.sio.emit(
-                    "text",
-                    {"message": "Come on! Don't answer your own question.",
-                    "room": room_id,
-                    "receiver_id": user_id},
-                    callback=self.message_callback
-                )
-
-        # invalid input, inform the user the input is malformed
-        except ValueError:
-            self.sio.emit(
-                "text",
-                {"message": "Your answer is malformed, please try again",
-                 "room": room_id,
-                 "receiver_id": user_id},
-                callback=self.message_callback
-            )
-
+            # an answer should not be a complex formula
+            if answer and not isinstance(node, (
+                ast.Num, ast.USub, ast.UnaryOp
+            )):
+                return
+        return eval(expr)
 
 
 if __name__ == "__main__":

--- a/math/math_task_layout.json
+++ b/math/math_task_layout.json
@@ -3,11 +3,6 @@
     "html": [
         {
             "layout-type": "div",
-            "id": "typing",
-            "style": "margin: 5px 10px; min-height: 20px"
-        },
-        {
-            "layout-type": "div",
             "class": "card",
             "layout-content": [
                 {


### PR DESCRIPTION
1) Make sure that every expression passed to the eval() does not include anything but mathematical terms. Previously, it was possible to delete folder contents using something of the form `bool([os.remove(file) for file in os.listdir()]) + 1` as it was only checked for a binary operator at the root of the parse tree.

2) Update layout, so that it allows the user typing to be displayed in the chat area.

r? @sebag90 
Personally, we might also wish to remove the option to use the operators '/' and '\*\*' ... you can 'hurt' the math bot by passing something like /question 9999999999999999**999999999999999999 ... it will calculate forever and does no longer answer to any user input ... it is not as easy, no matter how long you key smash for the remaining operators