### PR TITLE
Adding a script to update the wordlist

### DIFF
--- a/wordle/lib/update_wordlist.py
+++ b/wordle/lib/update_wordlist.py
@@ -1,0 +1,29 @@
+import pandas as pd
+
+
+def main():
+    # import the pairs file
+    df1 = pd.read_csv("../data/image_data.tsv", sep="\t", header=None)
+    df1.columns = ["term", "image_path"]
+
+    # import the existing wordslist
+    df2 = pd.read_csv("../data/wordlist.txt", sep="\n", header=None)
+    df2.columns = ["term"]
+
+    # update the existing wordslist
+    df3 = pd.concat([df1["term"], df2["term"]]).drop_duplicates().reset_index(drop=True)
+
+    # sort it alphabetically and replace it
+    df3 = df3.sort_values()
+    df3.to_csv("../data/wordlist.txt", sep="\n", index=False, header=False)
+
+    print("Wordlist updated!")
+    print(
+        "The wordlist has gained "
+        + str(len(df3.index) - len(df2.index))
+        + " new entries."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/wordle/lib/update_wordlist.py
+++ b/wordle/lib/update_wordlist.py
@@ -7,7 +7,7 @@ def main():
     df1.columns = ["term", "image_path"]
 
     # import the existing wordslist
-    df2 = pd.read_csv("../data/wordlist.txt", sep="\n", header=None)
+    df2 = pd.read_csv("../data/wordlist.txt", sep=" ", header=None)
     df2.columns = ["term"]
 
     # update the existing wordslist

--- a/wordle/requirements.txt
+++ b/wordle/requirements.txt
@@ -3,3 +3,4 @@ python-socketio == 5.3.0
 python-socketio[client]
 Requests
 scipy
+pandas


### PR DESCRIPTION
This PR adds a script to update the `wordlist.txt `when a new `image_data.tsv` file is available. 
It should be ideally integrated in the code, but as it is written at the moment it handles the image data and the wordlist separately. I would need a bit reorganisation to fit neatly. 

So at the moment it stays on it's own, as it won't need to be triggered often. 
To run the script:
1. upload the new `image_data.tsv` file
2. run `python update_wordlist.py`

The script will state how many entries are added. This is just the difference from the existing `wordlist.txt` file, which in most cases will contain the majority of the entries already. 