### PR TITLE
bots will also log their token

### DIFF
--- a/templates.py
+++ b/templates.py
@@ -33,7 +33,7 @@ class Bot(ABC):
         if port is not None:
             self.uri += f":{port}"
         self.uri += "/slurk/api"
-        logging.info(f"Running {self.__class__.__name__} on {self.uri} ...")
+        logging.info(f"Running {self.__class__.__name__} on {self.uri} with token: {self.token} ...")
 
         self.register_callbacks()
 


### PR DESCRIPTION
Bots will additionally log their token. This can be useful to keep track of which tokens are being used or to update the number of registrations left (usually just 1 for bots)