### PR TITLE
Wordle data collection

### DIFF
--- a/wordle/data/task_room_layout.json
+++ b/wordle/data/task_room_layout.json
@@ -4,6 +4,18 @@
   "html": [
     {
       "layout-type": "div",
+      "id": "fullscreen-overlay",
+      "layout-content": [
+        {
+          "layout-type": "div",
+          "id": "fullscreenButton",
+          "class": "button",
+          "layout-content": "Enter Fullscreen"
+        }
+      ]
+    },
+    {
+      "layout-type": "div",
       "class": "cards",
       "layout-content": [
         {
@@ -15,24 +27,35 @@
               "id": "instr",
               "layout-content": [
                 {
-                  "layout-type": "p",
-                  "style": "padding-bottom: 5px",
-                  "layout-content": "Together with your partner, guess the secret 5-letter word. The image gives you a hint, but the connection may be indirect."
+                  "layout-type": "button",
+                  "class": "collapsible",
+                  "layout-content": "Click to see task instructions"
                 },
                 {
-                  "layout-type": "p",
-                  "id": "mode",
-                  "style": "padding-bottom: 5px",
-                  "layout-content": ""
-                },
-                {
-                  "layout-type": "p",
-                  "style": "padding-bottom: 5px",
-                  "layout-content": "You must submit the same guess as your partner, so coordinate! If the guess is not correct, you get more hints."
-                },
-                {
-                  "layout-type": "p",
-                  "layout-content": "The earlier you guess the word, the more points you get, so put your heads together!"
+                  "layout-type": "div",
+                  "class": "collapsible-content",
+                  "layout-content": [
+                    {
+                      "layout-type": "p",
+                      "style": "padding-bottom: 5px",
+                      "layout-content": "Together with your partner, guess the secret 5-letter word. The image gives you a hint, but the connection may be indirect."
+                    },
+                    {
+                      "layout-type": "p",
+                      "id": "mode",
+                      "style": "padding-bottom: 5px",
+                      "layout-content": ""
+                    },
+                    {
+                      "layout-type": "p",
+                      "style": "padding-bottom: 5px",
+                      "layout-content": "You must submit the same guess as your partner, so coordinate! If the guess is not correct, you get more hints."
+                    },
+                    {
+                      "layout-type": "p",
+                      "layout-content": "The earlier you guess the word, the more points you get, so put your heads together!"
+                    }
+                  ]
                 },
                 {
                   "layout-type": "div",
@@ -373,6 +396,48 @@
     "#instr": {
       "text-justify": "inter-word",
       "margin": "10px"
+    },
+    "#fullscreenButton:hover": {
+      "background-color": "rgb(129, 139, 172)!important"
+    },
+    "#fullscreen-overlay":{
+      "background-color": "rgba(0,0,0,0.8)",
+      "position": "fixed",
+      "top": "0px",
+      "left": "0px",
+      "height": "100vh",
+      "width": "100vw",
+      "z-index": 3
+    },
+    "#fullscreenButton": {
+      "width": "300px",
+      "height": "100px",
+      "position": "absolute",
+      "left": "calc(50vw - 150px)",
+      "top": "calc(50vh - 90px)",
+      "font-size": "2em",
+      "border-radius": "100px",
+      "line-height": "100px",
+      "background-color": "white",
+      "text-align": "center",
+      "z-index": 4
+    },
+    ".collapsible": {
+      "background-color": "#eee",
+      "color": "#444",
+      "font-size": "1rem",
+      "cursor": "pointer",
+      "padding": "18px",
+      "width": "100%",
+      "border": "none",
+      "text-align": "left",
+      "outline": "none"
+    },
+    ".collapsible-content": {
+      "padding": "18px 18px",
+      "display": "none",
+      "overflow": "hidden",
+      "background-color": "#f1f1f1"
     }
   },
   "scripts": {
@@ -384,6 +449,6 @@
       "markdown-history"
     ],
     "typing-users": "typing-users",
-    "plain": "wordle"
+    "plain": ["collapsible-task-instructions","enforce-fullscreen","wordle"]
   }
 }

--- a/wordle/lib/config.py
+++ b/wordle/lib/config.py
@@ -36,8 +36,8 @@ PLATFORM = "Prolific"
 # They indicate how long a situation has to persist for something to happen.
 
 TIME_LEFT = 5  # how many minutes a user can stay in a room before closing it
-TIME_WAITING = 5  # how many minutes a user can wait for a partner
-TIME_ROUND = 15  # how many minutes users can play on a single image
+TIME_WAITING = 10  # how many minutes a user can wait for a partner
+TIME_ROUND = 20  # how many minutes users can play on a single image
 
 # colored messages
 COLOR_MESSAGE = '<a style="color:{color};">{message}</a>'

--- a/wordle/lib/config.py
+++ b/wordle/lib/config.py
@@ -19,6 +19,13 @@ SHUFFLE = True
 # What mode the game uses for showing images. one of "same", "different", "one_blind"
 GAME_MODE = "one_blind"
 
+# Whether the bot runs a public version or not
+# - This influences the kind of goodbye message
+# - Public data collections will not get a token but a tweetable message
+# - Set this to False when running data collections with AMT, Prolific, or similar
+# - Individual tokens will be generated when this is False
+PUBLIC = False
+
 # All below *TIME_* variables are in minutes.
 # They indicate how long a situation has to persist for something to happen.
 

--- a/wordle/lib/config.py
+++ b/wordle/lib/config.py
@@ -13,7 +13,7 @@ DATA_PATH = os.path.join(ROOT, "data", "image_data.tsv")
 WORD_LIST = os.path.join(ROOT, "data", "wordlist.txt")
 
 # This many game rounds will be played per room and player pair.
-N = 3
+N = 1
 # Set this seed to make the random process reproducible.
 SEED = None
 # Whether to randomly sample images or present them in linear order.

--- a/wordle/lib/config.py
+++ b/wordle/lib/config.py
@@ -5,6 +5,8 @@ import os
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+PROLIFIC_URL = "https://app.prolific.co/submissions/complete?cc="
+
 # Path to a comma separated (csv) file with two columns.
 # Each column containing the url to one image file.
 DATA_PATH = os.path.join(ROOT, "data", "image_data.tsv")
@@ -24,12 +26,17 @@ GAME_MODE = "one_blind"
 # - Public data collections will not get a token but a tweetable message
 # - Set this to False when running data collections with AMT, Prolific, or similar
 # - Individual tokens will be generated when this is False
+# - PLATFORM influences how the confirmation token will be supplied
+# - For Prolific, participants will receive a link
+# - For AMT, participants will get a token to copy
 PUBLIC = False
+PLATFORM = "Prolific"
 
 # All below *TIME_* variables are in minutes.
 # They indicate how long a situation has to persist for something to happen.
 
 TIME_LEFT = 5  # how many minutes a user can stay in a room before closing it
+TIME_WAITING = 5  # how many minutes a user can wait for a partner
 TIME_ROUND = 15  # how many minutes users can play on a single image
 
 # colored messages

--- a/wordle/lib/image_data.py
+++ b/wordle/lib/image_data.py
@@ -4,7 +4,7 @@
 import random
 
 
-class ImageData(dict):
+class ImageData(list):
     """Manage the access to image data.
 
     Mapping from room id to items left for this room.
@@ -44,6 +44,7 @@ class ImageData(dict):
             random.seed(seed)
 
         self._switch_order = self._switch_image_order()
+        self.get_word_image_pairs()
 
     @property
     def n(self):
@@ -53,7 +54,7 @@ class ImageData(dict):
     def mode(self):
         return self._mode
 
-    def get_word_image_pairs(self, room_id):
+    def get_word_image_pairs(self):
         """Create a collection of word/image pair items.
 
         Each item holds a word and 1 or 2 urls each to one image
@@ -64,9 +65,6 @@ class ImageData(dict):
         This function remembers previous calls to itself,
         which makes it possible to split a file of items over
         several participants even for not random sampling.
-
-        Args:
-            room_id (str): Unique identifier of a task room.
 
         Returns:
             None
@@ -105,9 +103,9 @@ class ImageData(dict):
                     new_sample.append((item[0], item[2], item[1]))
                 else:
                     new_sample.append(item)
-            self[room_id] = new_sample
+            self.extend(new_sample)
         else:
-            self[room_id] = sample
+            self.extend(sample)
 
     def _image_gen(self):
         """Generate one image pair at a time."""

--- a/wordle/lib/wordle_bot.py
+++ b/wordle/lib/wordle_bot.py
@@ -934,7 +934,6 @@ class WordleBot:
             json=json,
             headers={"Authorization": f"Bearer {self.token}"},
         )
-        self.request_feedback(response, "add token to display area")
 
         self._hide_image(room_id)
         self._hide_image_desc(room_id)

--- a/wordle/lib/wordle_bot.py
+++ b/wordle/lib/wordle_bot.py
@@ -493,6 +493,14 @@ class WordleBot:
                     "html": True,
                 },
             )
+            self.sio.emit(
+                "message_command",
+                {
+                    "command": {"command": "unsubmit"},
+                    "room": room_id,
+                    "receiver_id": curr_usr["id"],
+                },
+            )
             return
 
         # make sure it's a good guess

--- a/wordle/lib/wordle_bot.py
+++ b/wordle/lib/wordle_bot.py
@@ -28,7 +28,7 @@ from lib.config import (
     TIME_LEFT,
     TIME_ROUND,
     WARNING_COLOR,
-    WORD_LIST
+    WORD_LIST,
 )
 
 
@@ -46,6 +46,7 @@ class RoomTimers:
         and players get no points
 
     """
+
     def __init__(self):
         self.left_room = dict()
         self.round_timer = None
@@ -71,9 +72,7 @@ class RoomTimers:
         if isinstance(self.round_timer, Timer):
             self.round_timer.cancel()
 
-        timer = Timer(
-            TIME_ROUND * 60, function, args=[room_id]
-        )
+        timer = Timer(TIME_ROUND * 60, function, args=[room_id])
         timer.start()
         self.round_timer = timer
 
@@ -151,7 +150,7 @@ class WordleBot:
         self.url = self.uri
         self.uri += "/slurk/api"
 
-        self.sessions = SessionManager()        
+        self.sessions = SessionManager()
 
         self.public = PUBLIC
 
@@ -163,7 +162,7 @@ class WordleBot:
             self.wordlist = set((line.strip()) for line in infile)
         # ensure all the words from the initial image file are guessable
         with open(DATA_PATH) as infile:
-            self.wordlist.update(line.split('\t')[0] for line in infile)
+            self.wordlist.update(line.split("\t")[0] for line in infile)
 
         self.waiting_timer = None
         self.received_waiting_token = set()
@@ -188,7 +187,7 @@ class WordleBot:
             LOG.error(f"Could not {action}: {response.status_code}")
             response.raise_for_status()
         else:
-            LOG.debug(f'Successfully did {action}.')
+            LOG.debug(f"Successfully did {action}.")
 
     def register_callbacks(self):
         @self.sio.event
@@ -241,7 +240,9 @@ class WordleBot:
                 self.show_item(room_id)
 
                 # begin timers
-                self.sessions[room_id].timer.start_round_timer(self.time_out_round, room_id)
+                self.sessions[room_id].timer.start_round_timer(
+                    self.time_out_round, room_id
+                )
 
                 # show info to users
                 self._update_score_info(room_id)
@@ -252,14 +253,18 @@ class WordleBot:
             room_id = data["room"]
 
             mode_message = "In this game mode, "
-            if GAME_MODE == 'same':
+            if GAME_MODE == "same":
                 mode_message += "both of you see the same image."
-            elif GAME_MODE == 'different':
-                mode_message += "each of you sees a different image. " \
-                                "Both images are connected to the same word."
+            elif GAME_MODE == "different":
+                mode_message += (
+                    "each of you sees a different image. "
+                    "Both images are connected to the same word."
+                )
             else:
-                mode_message += "only one of you sees the image and " \
-                                "needs to describe it to the other person."
+                mode_message += (
+                    "only one of you sees the image and "
+                    "needs to describe it to the other person."
+                )
 
             response = requests.patch(
                 f"{self.uri}/rooms/{room_id}/text/mode",
@@ -289,7 +294,7 @@ class WordleBot:
                         "message": COLOR_MESSAGE.format(
                             color=STANDARD_COLOR,
                             message=f"Let's start with the first "
-                                    f"of {self.sessions[room_id].images.n} images",
+                            f"of {self.sessions[room_id].images.n} images",
                         ),
                         "room": room_id,
                         "html": True,
@@ -399,7 +404,13 @@ class WordleBot:
 
                             # close game, this user gets failure, other user success
                             self.sessions[room_id].game_over = True
-                            self.end_game(room_id, {curr_usr["id"]: "disconnection", other_usr["id"]: "success"})
+                            self.end_game(
+                                room_id,
+                                {
+                                    curr_usr["id"]: "disconnection",
+                                    other_usr["id"]: "success",
+                                },
+                            )
                             sleep(1)
                             self.close_room(room_id)
 
@@ -485,14 +496,14 @@ class WordleBot:
         response = requests.patch(
             f"{self.uri}/rooms/{room_id}/attribute/id/sidebar",
             headers={"Authorization": f"Bearer {self.token}"},
-            json={"attribute": "style", "value": f"width: {task_area}%"}
+            json={"attribute": "style", "value": f"width: {task_area}%"},
         )
         self.request_feedback(response, "resize sidebar")
 
         response = requests.patch(
             f"{self.uri}/rooms/{room_id}/attribute/id/content",
             headers={"Authorization": f"Bearer {self.token}"},
-            json={"attribute": "style", "value": f"width: {chat_area}%"}
+            json={"attribute": "style", "value": f"width: {chat_area}%"},
         )
         self.request_feedback(response, "resize content area")
 
@@ -518,7 +529,7 @@ class WordleBot:
                     "message": COLOR_MESSAGE.format(
                         color=STANDARD_COLOR,
                         message=f"Unfortunately this word is not valid. "
-                                f"Your guess needs to have {len(word)} letters.",
+                        f"Your guess needs to have {len(word)} letters.",
                     ),
                     "receiver_id": curr_usr["id"],
                     "room": room_id,
@@ -543,7 +554,7 @@ class WordleBot:
                     "message": COLOR_MESSAGE.format(
                         color=WARNING_COLOR,
                         message="**Unfortunately this word is not valid. "
-                                "Make sure that there aren't any typos**",
+                        "Make sure that there aren't any typos**",
                     ),
                     "receiver_id": curr_usr["id"],
                     "room": room_id,
@@ -606,7 +617,7 @@ class WordleBot:
                     "message": COLOR_MESSAGE.format(
                         color=STANDARD_COLOR,
                         message="Your partner thinks that you have "
-                                "found the right word. Enter your guess.",
+                        "found the right word. Enter your guess.",
                     ),
                     "receiver_id": other_usr["id"],
                     "room": room_id,
@@ -625,7 +636,7 @@ class WordleBot:
                     "message": COLOR_MESSAGE.format(
                         color=STANDARD_COLOR,
                         message="You and your partner sent a different word, "
-                                "please discuss and enter the same guess.",
+                        "please discuss and enter the same guess.",
                     ),
                     "room": room_id,
                     "html": True,
@@ -634,7 +645,10 @@ class WordleBot:
             self.sessions[room_id].guesses = dict()
             self.sio.emit(
                 "message_command",
-                {"command": {"command": "unsubmit"}, "room": room_id,},
+                {
+                    "command": {"command": "unsubmit"},
+                    "room": room_id,
+                },
             )
 
             return
@@ -693,7 +707,9 @@ class WordleBot:
     def _update_score_info(self, room):
         response = requests.patch(
             f"{self.uri}/rooms/{room}/text/subtitle",
-            json={"text": f"Your score is {self.sessions[room].points} – You have {len(self.sessions[room].images)} rounds to go."},
+            json={
+                "text": f"Your score is {self.sessions[room].points} – You have {len(self.sessions[room].images)} rounds to go."
+            },
             headers={"Authorization": f"Bearer {self.token}"},
         )
         self.request_feedback(response, "update score")
@@ -731,7 +747,9 @@ class WordleBot:
             # close the game, bot users get a success token
             curr_usr, other_usr = self.sessions[room_id].players
             self.sessions[room_id].game_over = True
-            self.end_game(room_id, {curr_usr["id"]: "success", other_usr["id"]: "success"})
+            self.end_game(
+                room_id, {curr_usr["id"]: "success", other_usr["id"]: "success"}
+            )
             sleep(1)
             self.close_room(room_id)
         else:
@@ -742,7 +760,7 @@ class WordleBot:
                     "message": COLOR_MESSAGE.format(
                         color=STANDARD_COLOR,
                         message=f"Ok, let's move on to the next round. "
-                                f"{len(self.sessions[room_id].images)} rounds to go!",
+                        f"{len(self.sessions[room_id].images)} rounds to go!",
                     ),
                     "room": room_id,
                     "html": True,
@@ -794,7 +812,7 @@ class WordleBot:
 
         if self.sessions[room_id].images:
             word, image_1, image_2 = self.sessions[room_id].images[0]
-            LOG.debug(f'{image_1}\n{image_2}')
+            LOG.debug(f"{image_1}\n{image_2}")
 
             # show a different image to each user. one image can be None
 
@@ -806,7 +824,11 @@ class WordleBot:
             if image_1:
                 response = requests.patch(
                     f"{self.uri}/rooms/{room_id}/attribute/id/current-image",
-                    json={"attribute": "src", "value": image_1, "receiver_id": user_1["id"]},
+                    json={
+                        "attribute": "src",
+                        "value": image_1,
+                        "receiver_id": user_1["id"],
+                    },
                     headers={"Authorization": f"Bearer {self.token}"},
                 )
                 self.request_feedback(response, "set image 1")
@@ -831,7 +853,11 @@ class WordleBot:
             if image_2:
                 response = requests.patch(
                     f"{self.uri}/rooms/{room_id}/attribute/id/current-image",
-                    json={"attribute": "src", "value": image_2, "receiver_id": user_2["id"]},
+                    json={
+                        "attribute": "src",
+                        "value": image_2,
+                        "receiver_id": user_2["id"],
+                    },
                     headers={"Authorization": f"Bearer {self.token}"},
                 )
                 self.request_feedback(response, "set image 2")
@@ -902,8 +928,8 @@ class WordleBot:
                 "message": COLOR_MESSAGE.format(
                     color=STANDARD_COLOR,
                     message="Please enter the following token into "
-                            "the field on the HIT webpage, and close "
-                            "this browser window.",
+                    "the field on the HIT webpage, and close "
+                    "this browser window.",
                 ),
                 "room": room_id,
                 "html": True,
@@ -923,9 +949,10 @@ class WordleBot:
         )
 
         # show token also in display area
-        json = {"text": f"Please enter the following token into the field "
-                f"on the HIT webpage, and close this browser "
-                f"window: {amt_token}"
+        json = {
+            "text": f"Please enter the following token into the field "
+            f"on the HIT webpage, and close this browser "
+            f"window: {amt_token}"
         }
         if receiver_id:
             json.update({"receiver_id": receiver_id})

--- a/wordle/lib/wordle_bot.py
+++ b/wordle/lib/wordle_bot.py
@@ -356,8 +356,7 @@ class WordleBot:
                         {
                             "message": COLOR_MESSAGE.format(
                                 color=STANDARD_COLOR,
-                                message=f"{curr_usr['name']} has left the game."
-                                        f" Please wait a bit, your partner may rejoin.",
+                                message=f"{curr_usr['name']} has left the game.",
                             ),
                             "room": room_id,
                             "receiver_id": other_usr["id"],
@@ -365,11 +364,14 @@ class WordleBot:
                         },
                     )
 
-                    LOG.debug(f"Starting Timer: left room for user {curr_usr['name']}")
-                    self.timers_per_room[room_id].left_room[curr_usr["id"]] = Timer(
-                        TIME_LEFT * 60, self.close_game, args=[room_id]
-                    )
-                    self.timers_per_room[room_id].left_room[curr_usr["id"]].start()
+                    # FIXME: this should not generate a success token
+                    self.close_game(room_id)
+
+                    # LOG.debug(f"Starting Timer: left room for user {curr_usr['name']}")
+                    # self.timers_per_room[room_id].left_room[curr_usr["id"]] = Timer(
+                    #     TIME_LEFT * 60, self.close_game, args=[room_id]
+                    # )
+                    # self.timers_per_room[room_id].left_room[curr_usr["id"]].start()
 
         @self.sio.event
         def text_message(data):

--- a/wordle/lib/wordle_bot.py
+++ b/wordle/lib/wordle_bot.py
@@ -987,15 +987,23 @@ class WordleBot:
         if self.data_collection == "AMT":
             self._show_amt_token(room_id, receiver_id, confirmation_token)
         elif self.data_collection == "Prolific":
-            self._show_prolific_link(room_id, receiver_id, confirmation_token)
+            self._show_prolific_link(room_id, receiver_id)
 
         self._hide_image(room_id)
         self._hide_image_desc(room_id)
 
         return confirmation_token
 
-    def _show_prolific_link(self, room, receiver, token):
-        # show token also in display area
+    def _show_prolific_link(self, room, receiver, token=None):
+
+        if token is None:
+            # use the username
+            response = requests.get(
+                f"{self.uri}/users/{receiver}",
+                headers={"Authorization": f"Bearer {self.token}"},
+            )
+            self.request_feedback(response, "get user")
+            token = response.json().get("name", f"{room}–{receiver}")
 
         url = f"{PROLIFIC_URL}{token}"
         self.sio.emit(

--- a/wordle/lib/wordle_bot.py
+++ b/wordle/lib/wordle_bot.py
@@ -1007,13 +1007,6 @@ class WordleBot:
              }
         )
 
-        response = requests.patch(
-            f"{self.uri}/rooms/{room}/text/instr",
-            json={"text": "", "receiver_id": receiver},
-            headers={"Authorization": f"Bearer {self.token}"},
-        )
-        self.request_feedback(response, "remove text from display area")
-
     def _show_amt_token(self, room, receiver, token):
         self.sio.emit(
             "text",
@@ -1041,21 +1034,7 @@ class WordleBot:
             },
         )
 
-        # show token also in display area
-        json = {
-            "text": f"Please enter the following token into the field "
-                    f"on the HIT webpage, and close this browser "
-                    f"window: {token}"
-        }
-        if receiver:
-            json.update({"receiver_id": receiver})
-
-        response = requests.patch(
-            f"{self.uri}/rooms/{room}/text/instr",
-            json=json,
-            headers={"Authorization": f"Bearer {self.token}"},
-        )
-        self.request_feedback(response, "show token in display area")
+        # TODO: show token also in display area
 
     def social_media_post(self, room_id, this_user_id, other_user_name):
         self.sio.emit(

--- a/wordle/lib/wordle_bot.py
+++ b/wordle/lib/wordle_bot.py
@@ -392,7 +392,6 @@ class WordleBot:
                         },
                     )
 
-                    # FIXME: this should not generate a success token
                     self.close_game(room_id, generate_token=False)
 
                     # LOG.debug(f"Starting Timer: left room for user {curr_usr['name']}")

--- a/wordle/lib/wordle_bot.py
+++ b/wordle/lib/wordle_bot.py
@@ -269,7 +269,7 @@ class WordleBot:
             response = requests.patch(
                 f"{self.uri}/rooms/{room_id}/text/mode",
                 json={"text": mode_message},
-                headers={"Authorization": f"Bearer {self.token}"},
+                headers={"Authorization": f"Bearer {self.token}"}
             )
             self.request_feedback(response, "add mode explanation")
 

--- a/wordle/lib/wordle_bot.py
+++ b/wordle/lib/wordle_bot.py
@@ -475,6 +475,23 @@ class WordleBot:
         guess = command["guess"]
         remaining_guesses = command["remaining"]
 
+        # make sure the guess has the right length
+        if len(word) != len(guess):
+            self.sio.emit(
+                "text",
+                {
+                    "message": COLOR_MESSAGE.format(
+                        color=STANDARD_COLOR,
+                        message=f"Unfortunately this word is not valid. "
+                                f"Your guess needs to have {len(word)} letters.",
+                    ),
+                    "receiver_id": curr_usr["id"],
+                    "room": room_id,
+                    "html": True,
+                },
+            )
+            return
+
         # make sure it's a good guess
         if guess not in self.wordlist:
             self.sio.emit(
@@ -490,21 +507,12 @@ class WordleBot:
                     "html": True,
                 },
             )
-            return
-
-        # make sure the guess has the right length
-        if len(word) != len(guess):
             self.sio.emit(
-                "text",
+                "message_command",
                 {
-                    "message": COLOR_MESSAGE.format(
-                        color=STANDARD_COLOR,
-                        message=f"Unfortunately this word is not valid. "
-                                f"Your guess needs to have {len(word)} letters.",
-                    ),
-                    "receiver_id": curr_usr["id"],
+                    "command": {"command": "unsubmit"},
                     "room": room_id,
-                    "html": True,
+                    "receiver_id": curr_usr["id"],
                 },
             )
             return
@@ -581,6 +589,11 @@ class WordleBot:
                 },
             )
             self.guesses_per_room[room_id] = dict()
+            self.sio.emit(
+                "message_command",
+                {"command": {"command": "unsubmit"}, "room": room_id,},
+            )
+
             return
 
         # both users think they are done with the game

--- a/wordle/plugins/wordle.js
+++ b/wordle/plugins/wordle.js
@@ -2,6 +2,7 @@ const NUMBER_OF_GUESSES = 6;
 let guessesRemaining = NUMBER_OF_GUESSES;
 let currentGuess = [];
 let nextLetter = 0;
+let submitted = false;  // whether a guess was submitted
 
 
 function initBoard() {
@@ -172,12 +173,13 @@ function getKeyPressed(letter) {
 
     let pressedKey = String(letter)
 
-    if (pressedKey === "DEL" && nextLetter !== 0) {
+    if (pressedKey === "DEL" && nextLetter !== 0 && !submitted) {
         deleteLetter()
         return
     }
 
     if (pressedKey === "ENTER") {
+        submitted = true;
         sendGuess()
         return
     }
@@ -219,6 +221,10 @@ $(document).ready(() => {
 
             } else if (data.command.command === "wordle_guess") {
                 checkGuess(data.command.guess, data.command.correct_word);
+                submitted = false;
+            } else if (data.command.command === "unsubmit") {
+                // happens when players submit different guesses
+                submitted = false;
             }
         }
     });

--- a/wordle/plugins/wordle.js
+++ b/wordle/plugins/wordle.js
@@ -48,10 +48,12 @@ function shadeKeyBoard(letter, color) {
 function deleteLetter() {
     let row = document.getElementsByClassName("letter-row")[6 - guessesRemaining]
     let box = row.children[nextLetter - 1]
-    box.textContent = ""
-    box.classList.remove("filled-box")
-    currentGuess.pop()
-    nextLetter -= 1
+    if (box){
+        box.textContent = ""
+        box.classList.remove("filled-box")
+        currentGuess.pop()
+        nextLetter -= 1
+    }
 }
 
 
@@ -210,12 +212,11 @@ $(document).ready(() => {
 
         if (typeof (data.command) === "object") {
             if (data.command.command === "wordle_init") {
-
                 guessesRemaining = NUMBER_OF_GUESSES;
                 currentGuess = [];
                 $("#keyboard-cont").show()
                 initBoard();
-                for (let i = 0; i < 5; i++) {
+                for (let i=0; i<5; i++) {
                     deleteLetter()
                 }
 

--- a/wordle/scripts/setup.sh
+++ b/wordle/scripts/setup.sh
@@ -64,7 +64,7 @@ docker run -e SLURK_TOKEN="$CONCIERGE_BOT_TOKEN" -e SLURK_USER=$CONCIERGE_BOT -e
 sleep 5
 
 # create cola bot
-WORDLE_BOT_TOKEN=$(check_response scripts/create_room_token.sh $WAITING_ROOM ../slurk-bots/wordle/data/wordle_bot_permissions.json | jq .id | sed 's/^"\(.*\)"$/\1/')
+WORDLE_BOT_TOKEN=$(check_response scripts/create_room_token.sh $WAITING_ROOM ../slurk-bots/wordle/data/bot_permissions.json | jq .id | sed 's/^"\(.*\)"$/\1/')
 echo "Wordle Bot Token: "
 echo $WORDLE_BOT_TOKEN
 WORDLE_BOT=$(check_response scripts/create_user.sh "WordleBot" "$WORDLE_BOT_TOKEN" | jq .id)
@@ -74,11 +74,11 @@ docker run -e SLURK_TOKEN=$WORDLE_BOT_TOKEN -e SLURK_USER=$WORDLE_BOT -e SLURK_W
 sleep 5
 
 # create two users
-USER1=$(check_response scripts/create_room_token.sh $WAITING_ROOM ../slurk-bots/wordle/data/wordle_user_permissions.json 1 $TASK_ID | jq .id | sed 's/^"\(.*\)"$/\1/')
+USER1=$(check_response scripts/create_room_token.sh $WAITING_ROOM ../slurk-bots/wordle/data/user_permissions.json 1 $TASK_ID | jq .id | sed 's/^"\(.*\)"$/\1/')
 echo $USER1
-USER2=$(check_response scripts/create_room_token.sh $WAITING_ROOM ../slurk-bots/wordle/data/wordle_user_permissions.json 1 $TASK_ID | jq .id | sed 's/^"\(.*\)"$/\1/')
+USER2=$(check_response scripts/create_room_token.sh $WAITING_ROOM ../slurk-bots/wordle/data/user_permissions.json 1 $TASK_ID | jq .id | sed 's/^"\(.*\)"$/\1/')
 echo $USER2
-USER3=$(check_response scripts/create_room_token.sh $WAITING_ROOM ../slurk-bots/wordle/data/wordle_user_permissions.json 1 $TASK_ID | jq .id | sed 's/^"\(.*\)"$/\1/')
+USER3=$(check_response scripts/create_room_token.sh $WAITING_ROOM ../slurk-bots/wordle/data/user_permissions.json 1 $TASK_ID | jq .id | sed 's/^"\(.*\)"$/\1/')
 echo $USER3
 
 cd ../slurk-bots

--- a/wordle/scripts/setup.sh
+++ b/wordle/scripts/setup.sh
@@ -78,5 +78,7 @@ USER1=$(check_response scripts/create_room_token.sh $WAITING_ROOM ../slurk-bots/
 echo $USER1
 USER2=$(check_response scripts/create_room_token.sh $WAITING_ROOM ../slurk-bots/wordle/data/wordle_user_permissions.json 1 $TASK_ID | jq .id | sed 's/^"\(.*\)"$/\1/')
 echo $USER2
+USER3=$(check_response scripts/create_room_token.sh $WAITING_ROOM ../slurk-bots/wordle/data/wordle_user_permissions.json 1 $TASK_ID | jq .id | sed 's/^"\(.*\)"$/\1/')
+echo $USER3
 
 cd ../slurk-bots

--- a/wordle/scripts/setup.sh
+++ b/wordle/scripts/setup.sh
@@ -20,11 +20,18 @@ docker build --tag "slurk/wordle-bot" -f wordle/Dockerfile .
 docker build --tag "slurk/concierge-bot" -f concierge/Dockerfile .
 
 # run slurk
+
+## copy plugins
+cp wordle/wordle.js ../slurk/slurk/views/static/plugins/
+
+
 cd ../slurk
 docker build --tag="slurk/server" -f Dockerfile .
 export SLURK_DOCKER=slurk
 scripts/start_server.sh
 sleep 5
+
+rm slurk/views/static/plugins/wordle.js
 
 # create admin token
 SLURK_TOKEN=$(check_response scripts/read_admin_token.sh)


### PR DESCRIPTION
- enforce full screen in browser for playing
- hide task instructions in a collapsible box that the user can open by clicking on it
- improve the wordle logic and tell the user what went wrong, e.g. when their guess is too short
- add any missing words when starting the bot with an image list
- add a public mode that issues a social media message instead of a token
- when a token is issued, also show it in the display area
- remove message that users might rejoin