### PR TITLE
add a function to be executed upon new task room creation

### DIFF
--- a/echo/__main__.py
+++ b/echo/__main__.py
@@ -35,25 +35,12 @@ class RoomTimer:
 class EchoBot(TaskBot):
     timers_per_room = dict()
 
-    def join_task_room(self):
-        """Let the bot join an assigned task room."""
+    def on_task_room_creation(self, data):
+        room_id = data["room"]
 
-        def join(data):
-            if self.task_id is None or data["task"] != self.task_id:
-                return
-
-            room_id = data["room"]
-
-            response = requests.post(
-                f"{self.uri}/users/{self.user}/rooms/{room_id}",
-                headers={"Authorization": f"Bearer {self.token}"},
-            )
-            self.request_feedback(response, f"let {self.__class__.__name__}  join room")
-            self.timers_per_room[room_id] = RoomTimer(
-                self.close_room, room_id
-            )
-
-        return join
+        self.timers_per_room[room_id] = RoomTimer(
+            self.close_room, room_id
+        )
 
     def close_room(self, room_id):
         self.room_to_read_only(room_id)

--- a/templates.py
+++ b/templates.py
@@ -131,6 +131,11 @@ class TaskBot(Bot):
         self.task_id = task
         self.sio.on("new_task_room", self.join_task_room())
 
+    def on_task_room_creation(self, data):
+        """Each bot can define some actions to be performed upon
+        task room creation."""
+        pass
+
     def join_task_room(self):
         """Let the bot join an assigned task room."""
 
@@ -143,6 +148,7 @@ class TaskBot(Bot):
                 headers={"Authorization": f"Bearer {self.token}"},
             )
             self.request_feedback(response, f"let {self.__class__.__name__}  join room")
+            self.on_task_room_creation(data)
 
         return join
 


### PR DESCRIPTION
All Bots that inherit from the TaskBot class need to redefine the entire function that is called once the bot received a new_task_room event. This is cumbersome and leads to unnecessary code duplication.

This pull requests creates a new method `on_task_room_creation(data)` that is called in the TaskBot class once the new_task_room event is received. Since not all bots require this function, it is defined with a `pass` in the TaskBot class and can be redefined in those bots that need this function.

an example on how to use this new method is shown in the Echo Bot