### PR TITLE
update start_bot.py and add a script to generate new tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ OTHER_VARIABLE = World
 #### Credentials file
 Instead of passing the address of your slurk server and an API-Token to the script as single arguments, you can instead use the `--credentials-from-file` option to pass a configuration file containing this information. Your file must have the following formatting:
 ```
-[SLURK CREDENTIALS]
+[SLURK]
 host = https://slurk.your-website.com
 token = 00000000-0000-0000-0000-000000000000
 ```
@@ -115,23 +115,24 @@ If you need to generate extra tokens for a bot that is already running you can u
 
 ### Synopsis
 ```
-usage: generate_tokens.py [-h] [--user-permissions USER_PERMISSIONS] --n-tokens N_TOKENS [--slurk-host SLURK_HOST] [--slurk-api-token SLURK_API_TOKEN] [--credentials-from-file CREDENTIALS_FROM_FILE]
-                          --waiting-room-id WAITING_ROOM_ID --task-id TASK_ID
+usage: generate_tokens.py [-h] [--user-permissions USER_PERMISSIONS] --n-tokens N_TOKENS [--slurk-host SLURK_HOST] [--slurk-api-token SLURK_API_TOKEN] [--waiting-room-id WAITING_ROOM_ID] [--task-id TASK_ID]
+                          [--complete-links] [--config-file CONFIG_FILE]
 
-options:
+optional arguments:
   -h, --help            show this help message and exit
   --user-permissions USER_PERMISSIONS
                         path to the file containing the user permissions (default: None)
   --n-tokens N_TOKENS   number of tokens to generate (default: None)
   --slurk-host SLURK_HOST
-                        api address to your slurk server (default: http://127.0.0.1:5000)
+                        address to your slurk server (default: http://127.0.0.1:5000)
   --slurk-api-token SLURK_API_TOKEN
                         slurk token with api permissions (default: 00000000-0000-0000-0000-000000000000)
-  --credentials-from-file CREDENTIALS_FROM_FILE
-                        read slurk host and api token from a json file (default: None)
   --waiting-room-id WAITING_ROOM_ID
                         room_id of an existing waiting room. (default: None)
   --task-id TASK_ID     task_id of an existing task (default: None)
+  --complete-links      The script will print out complete links with random names instead of tokens alone (default: False)
+  --config-file CONFIG_FILE
+                        read slurk and bot parameters from a configuration file (default: None)
 ```
 
 
@@ -140,10 +141,21 @@ Other options:
 * `--n-tokens INT`: number of tokens to generate.
 * `--slurk-host https://slurk.your-website.com`: the address of your slurk server. Since the standard value is localhost:5000, you can omit this when developing locally.
 * `--slurk-api-token: YOUR-API-TOKEN`: a slurk token with api rights to create a new bot. The standard value is `00000000-0000-0000-0000-000000000000` so you can omit this option when developing locally.
-* `--credentials-from-file`: read slurk host and api token from a configuration file. See the Assumptions session for more information about the formatting for the credentials file.
 * `--waiting-room-id N`: you can reuse an existing waiting room for your bot instead of creating a new one. When this option is passed, the script will not start an additional concierge bot.
 * `--task-id N`: similarly to `--waiting-room-id` you can reuse a waiting room layout id, this option will, however, start a concierge bot for the newly created waiting room.
+* `--complete-links`: instead of printing only tokens, the script will generate random names and print out a complete slurk link for anonymous login.
+* `--config-file`: slurk credentials (host and api) and bot information (task id and waiting room id) are read from a configuration file. An example of the configuration file can be seen in the section below.
 
+### Configuration file
+```
+[SLURK]
+host = https://slurk.your-website.com
+token = 00000000-0000-0000-0000-000000000000
+
+[BOT]
+task_id = 1
+waiting_room_id = 1
+```
 
 ### Examples
 Generate 10 new tokens for the task_id 15 with waiting room 12  

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To start any bot you can use the `start_bot.py` script. The script can be used t
 
 ### Synopsis
 ```
-usage: start_bot.py [-h] [--extra-args EXTRA_ARGS] [--bot-name BOT_NAME] --users USERS [--slurk-host SLURK_HOST] [--slurk-api-token SLURK_API_TOKEN] [--credentials-from-file CREDENTIALS_FROM_FILE] [--waiting-room-id WAITING_ROOM_ID] [--waiting-room-layout-id WAITING_ROOM_LAYOUT_ID] [--waiting-room-layout-dict WAITING_ROOM_LAYOUT_DICT] [--tokens] [--dev] [--copy-plugins]
+usage: start_bot.py [-h] [--extra-args EXTRA_ARGS] [--bot-name BOT_NAME] --users USERS [--slurk-host SLURK_HOST] [--slurk-api-token SLURK_API_TOKEN] [--config_file CONFIG_FILE] [--waiting-room-id WAITING_ROOM_ID] [--waiting-room-layout-id WAITING_ROOM_LAYOUT_ID] [--waiting-room-layout-dict WAITING_ROOM_LAYOUT_DICT] [--tokens] [--dev] [--copy-plugins]
                     bot
 
 positional arguments:
@@ -26,7 +26,7 @@ options:
                         api address to your slurk server (default: http://127.0.0.1:5000)
   --slurk-api-token SLURK_API_TOKEN
                         slurk token with api permissions (default: 00000000-0000-0000-0000-000000000000)
-  --credentials-from-file CREDENTIALS_FROM_FILE
+  --config_file CREDENTIALS_FROM_FILE
                         read slurk host and api token from a json file (default: None)
   --waiting-room-id WAITING_ROOM_ID
                         room_id of an existing waiting room. With this option will not create a new waiting room or a concierge bot (default: None)
@@ -48,7 +48,7 @@ Other options:
 * `--slurk-host https://slurk.your-website.com`: the address of your slurk server. Since the standard value is localhost:5000, you can omit this when developing locally.
 * `--users N`: the number of users required for this task.
 * `--slurk-api-token: YOUR-API-TOKEN`: a slurk token with api rights to create a new bot. The standard value is `00000000-0000-0000-0000-000000000000` so you can omit this option when developing locally.
-* `--credentials-from-file`: read slurk host and api token from a configuration file. See the Assumptions session for more information about the formatting for the credentials file.
+* `--config_file`: read slurk host and api token from a configuration file. See the Assumptions session for more information about the formatting for the configuration file.
 * `--waiting-room-id N`: you can reuse an existing waiting room for your bot instead of creating a new one. When this option is passed, the script will not start an additional concierge bot.
 * `--waiting-room-layout-id N`: similarly to `--waiting-room-id` you can reuse a waiting room layout id, this option will, however, start a concierge bot for the newly created waiting room.
 * `--waiting-room-layout-dict`: with this argument you can specify which layout file you want to load for your waiting room. The default value will use the layout in the `concierge` directory.
@@ -73,7 +73,7 @@ OTHER_VARIABLE = World
 ```
 
 #### Credentials file
-Instead of passing the address of your slurk server and an API-Token to the script as single arguments, you can instead use the `--credentials-from-file` option to pass a configuration file containing this information. Your file must have the following formatting:
+Instead of passing the address of your slurk server and an API-Token to the script as single arguments, you can instead use the `--config-file` option to pass a configuration file containing this information. Your file must have the following formatting:
 ```
 [SLURK]
 host = https://slurk.your-website.com
@@ -107,7 +107,7 @@ $ python start_bot.py echo/ --users 1 --tokens \
     --slurk-api-token 01234567-8901-2345-6789-012345678901
 ```
 or save your credentials in a configuration file and pass this as an argument to the script:  
-`$ python start_bot.py echo/ --users 1 --tokens --credentials-from-file path/to/credentials.ini`
+`$ python start_bot.py echo/ --users 1 --tokens --config_file path/to/config.ini`
 
 
 ## generate extra tokens  

--- a/README.md
+++ b/README.md
@@ -111,7 +111,10 @@ or save your credentials in a configuration file and pass this as an argument to
 
 
 ## generate extra tokens  
-If you need to generate extra tokens for a bot that is already running you can use the `generate_tokens.py` file
+If you need to generate extra tokens for a bot that is already running you can use the `generate_tokens.py` file.
+
+### Requirements
+This script requires the [`randomname`](https://github.com/beasteers/randomname) package
 
 ### Synopsis
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To start any bot you can use the `start_bot.py` script. The script can be used t
 
 ### Synopsis
 ```
-usage: start_bot.py [-h] [--extra-args EXTRA_ARGS] [--bot-name BOT_NAME] --users USERS [--slurk-host SLURK_HOST] [--slurk-api-token SLURK_API_TOKEN] [--config_file CONFIG_FILE] [--waiting-room-id WAITING_ROOM_ID] [--waiting-room-layout-id WAITING_ROOM_LAYOUT_ID] [--waiting-room-layout-dict WAITING_ROOM_LAYOUT_DICT] [--tokens] [--dev] [--copy-plugins]
+usage: start_bot.py [-h] [--extra-args EXTRA_ARGS] [--bot-name BOT_NAME] --users USERS [--slurk-host SLURK_HOST] [--slurk-api-token SLURK_API_TOKEN] [--config-file CONFIG_FILE] [--waiting-room-id WAITING_ROOM_ID] [--waiting-room-layout-id WAITING_ROOM_LAYOUT_ID] [--waiting-room-layout-dict WAITING_ROOM_LAYOUT_DICT] [--tokens] [--dev] [--copy-plugins]
                     bot
 
 positional arguments:
@@ -26,7 +26,7 @@ options:
                         api address to your slurk server (default: http://127.0.0.1:5000)
   --slurk-api-token SLURK_API_TOKEN
                         slurk token with api permissions (default: 00000000-0000-0000-0000-000000000000)
-  --config_file CREDENTIALS_FROM_FILE
+  --config-file CREDENTIALS_FROM_FILE
                         read slurk host and api token from a json file (default: None)
   --waiting-room-id WAITING_ROOM_ID
                         room_id of an existing waiting room. With this option will not create a new waiting room or a concierge bot (default: None)
@@ -48,7 +48,7 @@ Other options:
 * `--slurk-host https://slurk.your-website.com`: the address of your slurk server. Since the standard value is localhost:5000, you can omit this when developing locally.
 * `--users N`: the number of users required for this task.
 * `--slurk-api-token: YOUR-API-TOKEN`: a slurk token with api rights to create a new bot. The standard value is `00000000-0000-0000-0000-000000000000` so you can omit this option when developing locally.
-* `--config_file`: read slurk host and api token from a configuration file. See the Assumptions session for more information about the formatting for the configuration file.
+* `--config-file`: read slurk host and api token from a configuration file. See the Assumptions session for more information about the formatting for the configuration file.
 * `--waiting-room-id N`: you can reuse an existing waiting room for your bot instead of creating a new one. When this option is passed, the script will not start an additional concierge bot.
 * `--waiting-room-layout-id N`: similarly to `--waiting-room-id` you can reuse a waiting room layout id, this option will, however, start a concierge bot for the newly created waiting room.
 * `--waiting-room-layout-dict`: with this argument you can specify which layout file you want to load for your waiting room. The default value will use the layout in the `concierge` directory.
@@ -107,7 +107,7 @@ $ python start_bot.py echo/ --users 1 --tokens \
     --slurk-api-token 01234567-8901-2345-6789-012345678901
 ```
 or save your credentials in a configuration file and pass this as an argument to the script:  
-`$ python start_bot.py echo/ --users 1 --tokens --config_file path/to/config.ini`
+`$ python start_bot.py echo/ --users 1 --tokens --config-file path/to/config.ini`
 
 
 ## generate extra tokens  

--- a/README.md
+++ b/README.md
@@ -108,3 +108,57 @@ $ python start_bot.py echo/ --users 1 --tokens \
 ```
 or save your credentials in a configuration file and pass this as an argument to the script:  
 `$ python start_bot.py echo/ --users 1 --tokens --credentials-from-file path/to/credentials.ini`
+
+
+## generate extra tokens  
+If you need to generate extra tokens for a bot that is already running you can use the `generate_tokens.py` file
+
+### Synopsis
+```
+usage: generate_tokens.py [-h] [--user-permissions USER_PERMISSIONS] --n-tokens N_TOKENS [--slurk-host SLURK_HOST] [--slurk-api-token SLURK_API_TOKEN] [--credentials-from-file CREDENTIALS_FROM_FILE]
+                          --waiting-room-id WAITING_ROOM_ID --task-id TASK_ID
+
+options:
+  -h, --help            show this help message and exit
+  --user-permissions USER_PERMISSIONS
+                        path to the file containing the user permissions (default: None)
+  --n-tokens N_TOKENS   number of tokens to generate (default: None)
+  --slurk-host SLURK_HOST
+                        api address to your slurk server (default: http://127.0.0.1:5000)
+  --slurk-api-token SLURK_API_TOKEN
+                        slurk token with api permissions (default: 00000000-0000-0000-0000-000000000000)
+  --credentials-from-file CREDENTIALS_FROM_FILE
+                        read slurk host and api token from a json file (default: None)
+  --waiting-room-id WAITING_ROOM_ID
+                        room_id of an existing waiting room. (default: None)
+  --task-id TASK_ID     task_id of an existing task (default: None)
+```
+
+
+Other options:
+* `--user-permissions PATH/TO/PERMISSIONS.JSON`: you can pass a json file containing the user's permissions. If omitted, the standard permissions will be loaded: `{"send_message": True, "send_command": True}`
+* `--n-tokens INT`: number of tokens to generate.
+* `--slurk-host https://slurk.your-website.com`: the address of your slurk server. Since the standard value is localhost:5000, you can omit this when developing locally.
+* `--slurk-api-token: YOUR-API-TOKEN`: a slurk token with api rights to create a new bot. The standard value is `00000000-0000-0000-0000-000000000000` so you can omit this option when developing locally.
+* `--credentials-from-file`: read slurk host and api token from a configuration file. See the Assumptions session for more information about the formatting for the credentials file.
+* `--waiting-room-id N`: you can reuse an existing waiting room for your bot instead of creating a new one. When this option is passed, the script will not start an additional concierge bot.
+* `--task-id N`: similarly to `--waiting-room-id` you can reuse a waiting room layout id, this option will, however, start a concierge bot for the newly created waiting room.
+
+
+### Examples
+Generate 10 new tokens for the task_id 15 with waiting room 12  
+`$ python generate_tokens.py --task-id 15 --waiting-room-id 12 --n-tokens 10`
+
+output: 
+```
+f88f4ef5-8f3c-4ed0-b99c-702edc5d1199
+1ba266d9-b30a-4869-9674-cb08227a5ea3
+ef28b628-6eae-495c-bc17-67c073fa1202
+1fbe5aec-2e83-46d9-b1b7-988e7b17075a
+afbdcf81-5676-42cf-bdd4-7f9cb0308f70
+506bf0e2-80a6-4b00-9f84-588459fd7634
+966dd82f-a835-47b4-a878-3b6521353154
+35fb09a7-6a84-4348-b837-11a532d7cb92
+62c8f625-64a6-4be6-b3e7-3125fcb13a32
+e20c03ca-d4e4-4efd-af1a-c97bcc610c7b
+```

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ or save your credentials in a configuration file and pass this as an argument to
 If you need to generate extra tokens for a bot that is already running you can use the `generate_tokens.py` file.
 
 ### Requirements
-This script requires the [`randomname`](https://github.com/beasteers/randomname) package
+This script requires the [`randomname`](https://github.com/beasteers/randomname) package.
 
 ### Synopsis
 ```

--- a/generate_tokens.py
+++ b/generate_tokens.py
@@ -120,9 +120,9 @@ if __name__ == "__main__":
     WAITING_ROOM_ID = args.waiting_room_id
 
     if args.config_file:
-        credentials_file = Path(args.config_file)
-        if not credentials_file.exists():
-            raise FileNotFoundError("Missing file with slurk credentials")
+        config_file = Path(args.config_file)
+        if not config_file.exists():
+            raise FileNotFoundError("Missing configuration file with slurk credentials")
 
         config = configparser.ConfigParser()
         config.read(Path(args.config_file))

--- a/generate_tokens.py
+++ b/generate_tokens.py
@@ -1,0 +1,125 @@
+import argparse
+import configparser
+import json
+from pathlib import Path
+
+
+import requests
+
+
+def create_permissions(permissions):
+    response = requests.post(
+        f"{SLURK_API}/permissions",
+        headers={"Authorization": f"Bearer {API_TOKEN}"},
+        json=permissions,
+    )
+
+    if not response.ok:
+        print("could not create permissions")
+        response.raise_for_status()
+
+    return response.json()["id"]
+
+
+def create_token(permissions, room_id, task_id=None):
+    response = requests.post(
+        f"{SLURK_API}/tokens",
+        headers={"Authorization": f"Bearer {API_TOKEN}"},
+        json={
+            "permissions_id": permissions,
+            "room_id": room_id,
+            "registrations_left": 1,
+            "task_id": task_id,
+        },
+    )
+
+    if not response.ok:
+        print("could not create token")
+        response.raise_for_status()
+
+    return response.json()["id"]
+
+
+def main(args):
+    if args.user_permissions is None:
+        user_permissions_dict = {"send_message": True, "send_command": True}
+
+    else:
+        user_permissions_dict = json.loads(
+            Path(args.user_permissions).read_text(encoding="utf-8")
+        )
+
+    for user in range(args.n_tokens):
+        user_permissions_id = create_permissions(user_permissions_dict)
+        user_token = create_token(
+            user_permissions_id, args.waiting_room_id, args.task_id
+        )
+        print(user_token)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument(
+        "--user-permissions",
+        help="path to the file containing the user permissions",
+    )
+    parser.add_argument(
+        "--n-tokens",
+        help="number of tokens to generate",
+        required=True,
+        type=int,
+    )
+    parser.add_argument(
+        "--slurk-host",
+        default="http://127.0.0.1:5000",
+        help="api address to your slurk server",
+    )
+    parser.add_argument(
+        "--slurk-api-token",
+        help="slurk token with api permissions",
+        default="00000000-0000-0000-0000-000000000000",
+    )
+    parser.add_argument(
+        "--credentials-from-file", help="read slurk host and api token from a json file"
+    )
+    parser.add_argument(
+        "--waiting-room-id",
+        type=int,
+        help="room_id of an existing waiting room.",
+        required=True,
+    )
+    parser.add_argument(
+        "--task-id",
+        type=int,
+        help="task_id of an existing task",
+        required=True,
+    )
+
+    args = parser.parse_args()
+
+    # define some variables here
+    SLURK_HOST = args.slurk_host
+    SLURK_API = f"{args.slurk_host}/slurk/api"
+    API_TOKEN = args.slurk_api_token
+
+    if args.credentials_from_file:
+        credentials_file = Path(args.credentials_from_file)
+        if not credentials_file.exists():
+            raise FileNotFoundError("Missing file with slurk credentials")
+
+        config = configparser.ConfigParser()
+        config.read(Path(args.credentials_from_file))
+        config.sections()
+
+        if any(config["SLURK CREDENTIALS"].get(i) is None for i in ["host", "token"]):
+            raise ValueError("Invalid formatting for credentials file")
+
+        sulrk_address = config.get("SLURK CREDENTIALS", "host")
+        SLURK_HOST = sulrk_address
+        SLURK_API = f"{sulrk_address}/slurk/api"
+        API_TOKEN = config.get("SLURK CREDENTIALS", "token")
+
+    # start bot
+    main(args)

--- a/generate_tokens.py
+++ b/generate_tokens.py
@@ -134,9 +134,9 @@ if __name__ == "__main__":
         if any(config["BOT"].get(i) is None for i in ["task_id", "waiting_room_id"]):
             raise ValueError("Config file is missing slurk entries")
 
-        sulrk_address = config.get("SLURK", "host")
-        SLURK_HOST = sulrk_address
-        SLURK_API = f"{sulrk_address}/slurk/api"
+        slurk_address = config.get("SLURK", "host")
+        SLURK_HOST = slurk_address
+        SLURK_API = f"{slurk_address}/slurk/api"
         API_TOKEN = config.get("SLURK", "token")
 
         TASK_ID = int(config.get("BOT", "task_id"))

--- a/start_bot.py
+++ b/start_bot.py
@@ -396,7 +396,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--slurk-host",
         default="http://127.0.0.1:5000",
-        help="api address to your slurk server",
+        help="address to your slurk server",
     )
     parser.add_argument(
         "--slurk-api-token",
@@ -452,13 +452,13 @@ if __name__ == "__main__":
         config.read(Path(args.credentials_from_file))
         config.sections()
 
-        if any(config["SLURK CREDENTIALS"].get(i) is None for i in ["host", "token"]):
+        if any(config["SLURK"].get(i) is None for i in ["host", "token"]):
             raise ValueError("Invalid formatting for credentials file")
 
-        sulrk_address = config.get("SLURK CREDENTIALS", "host")
+        sulrk_address = config.get("SLURK", "host")
         SLURK_HOST = sulrk_address
         SLURK_API = f"{sulrk_address}/slurk/api"
-        API_TOKEN = config.get("SLURK CREDENTIALS", "token")
+        API_TOKEN = config.get("SLURK", "token")
 
     # start bot
     main(args)

--- a/start_bot.py
+++ b/start_bot.py
@@ -20,7 +20,7 @@ Examples:
 
     or save your credentials in a configuration file and pass this as an argument to the script:
     $ python start_bot.py echo/ --users 1 --tokens \
-        --credentials-from-file path/to/credentials.ini
+        --config-file path/to/config.ini
 """
 
 import argparse
@@ -404,7 +404,7 @@ if __name__ == "__main__":
         default="00000000-0000-0000-0000-000000000000",
     )
     parser.add_argument(
-        "--credentials-from-file", help="read slurk host and api token from a json file"
+        "--config-file", help="read slurk host and api token from a configuration file"
     )
     parser.add_argument(
         "--waiting-room-id",
@@ -443,17 +443,17 @@ if __name__ == "__main__":
     SLURK_API = f"{args.slurk_host}/slurk/api"
     API_TOKEN = args.slurk_api_token
 
-    if args.credentials_from_file:
-        credentials_file = Path(args.credentials_from_file)
-        if not credentials_file.exists():
+    if args.config_file:
+        config_file = Path(args.config_file)
+        if not config_file.exists():
             raise FileNotFoundError("Missing file with slurk credentials")
 
         config = configparser.ConfigParser()
-        config.read(Path(args.credentials_from_file))
+        config.read(Path(args.config_file))
         config.sections()
 
         if any(config["SLURK"].get(i) is None for i in ["host", "token"]):
-            raise ValueError("Invalid formatting for credentials file")
+            raise ValueError("Invalid formatting for configuration file")
 
         slurk_address = config.get("SLURK", "host")
         SLURK_HOST = slurk_address

--- a/start_bot.py
+++ b/start_bot.py
@@ -455,9 +455,9 @@ if __name__ == "__main__":
         if any(config["SLURK"].get(i) is None for i in ["host", "token"]):
             raise ValueError("Invalid formatting for credentials file")
 
-        sulrk_address = config.get("SLURK", "host")
-        SLURK_HOST = sulrk_address
-        SLURK_API = f"{sulrk_address}/slurk/api"
+        slurk_address = config.get("SLURK", "host")
+        SLURK_HOST = slurk_address
+        SLURK_API = f"{slurk_address}/slurk/api"
         API_TOKEN = config.get("SLURK", "token")
 
     # start bot

--- a/start_bot.py
+++ b/start_bot.py
@@ -244,7 +244,11 @@ def main(args):
         waiting_room_id = create_room(waiting_room_layout)
 
         # create a concierge bot for this room
-        concierge_name = f"concierge-bot-{waiting_room_id}"
+        if "concierge" in args.bot:
+            bot_name = args.bot_name or str(bot_base_path)
+            concierge_name = f"{bot_name}-{waiting_room_id}"
+        else:
+            concierge_name = f"concierge-{waiting_room_id}"
 
         concierge_bot_permissions_file = find_bot_permissions_file(Path("concierge"))
         concierge_permissions_dict = json.loads(
@@ -264,6 +268,8 @@ def main(args):
                 "--network",
                 "host",
                 "-d",
+                "-e",
+                f"WAITING_ROOM={waiting_room_id}",
                 "-e",
                 f"BOT_TOKEN={concierge_bot_token}",
                 "-e",


### PR DESCRIPTION
update the `start_bot.py`:
- allow custom naming of the concierge bot if the concierge bot is being started alone
- add the waiting room id to the environment variables of the concierge bot for easier identification through the `docker inspect` command

add the `generate_tokens.py` script to generate new tokens for a bot that is already running